### PR TITLE
feat: add thread context (root_id) to inbound meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 bun.lock
 .env
+.DS_Store

--- a/server.ts
+++ b/server.ts
@@ -963,6 +963,11 @@ async function handleInbound(event: any): Promise<void> {
       : new Date().toISOString(),
   }
 
+  // Thread context: root_id is set when the message is inside a thread
+  if (message.root_id) {
+    meta.thread_root_id = message.root_id
+  }
+
   // Auto-download image attachments (from 'image' or 'post' with embedded images)
   const imageKey = extractImageKey(msgType, contentStr)
   if (imageKey) {


### PR DESCRIPTION
## Summary

- スレッド内メッセージの場合、`thread_root_id` を meta に追加
- Claude がスレッド内の会話か通常チャットかを区別できるようになる
- `.gitignore` に `.DS_Store` を追加

## Test plan

- [x] スレッド内でメンション → meta に `thread_root_id` が含まれる
- [x] 通常メッセージ → `thread_root_id` が含まれない

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message threading by improving how thread context relationships are recognized and tracked for related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->