### PR TITLE
fix: reply inside threads when thread_root_id is present

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -603,6 +603,8 @@ const mcp = new Server(
       '',
       'Messages from Lark arrive as <channel source="lark" chat_id="..." message_id="..." user="..." ts="...">. If the tag has an image_path attribute, Read that file — it is an image the sender attached. If it has reply_to_text, that is the message the sender is replying to (quoted context). If it has reply_to_image_path, Read that file — it is an image from the quoted message. Reply with the reply tool — pass chat_id back. Use reply_to (set to a message_id) only when replying to an earlier message; the latest message doesn\'t need a quote-reply, omit reply_to for normal responses.',
       '',
+      'When the <channel> tag has a thread_root_id attribute, the message is inside a Lark thread. You MUST pass reply_to with the message_id so your response stays in the same thread. Never reply to the main chat when thread_root_id is present.',
+      '',
       'reply accepts file paths (files: ["/abs/path.png"]) for attachments. Images are sent as Lark image messages; other files as documents. Use react to add emoji reactions (Lark emoji type names like THUMBSUP, HEART, SMILE), and edit_message to update a message you previously sent.',
       '',
       'fetch_messages pulls recent Lark chat history. download_attachment fetches file/image attachments by message ID.',


### PR DESCRIPTION
## Summary

- スレッド内メッセージへの返信がメインチャットに送信される問題を修正
- MCP server の instructions に「`thread_root_id` がある場合は `reply_to` を必ず使う」指示を追加
- #20 (`thread_root_id` meta 追加) と組み合わせて動作

## Test plan

- [x] スレッド内でメンション → 返信がスレッド内に送信される
- [x] 通常メッセージ → 従来通りメインチャットに返信

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed threaded message handling in Lark integration to ensure responses are sent to the correct conversation thread instead of the main chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->